### PR TITLE
Use Path::Tiny->tempfile instead of File::Temp

### DIFF
--- a/lib/Devel/IPerl/Plugin/PDLGraphicsGnuplot.pm
+++ b/lib/Devel/IPerl/Plugin/PDLGraphicsGnuplot.pm
@@ -27,7 +27,7 @@ package
 
 use Moo::Role;
 use Capture::Tiny qw(capture_stderr capture_stdout);
-use File::Temp;
+use Path::Tiny;
 
 around new => sub {
 	my $orig = shift;
@@ -75,15 +75,11 @@ sub iperl_data_representations {
 	my $suffix = $format_info->{$format}{suffix};
 	my $displayable = $format_info->{$format}{displayable};
 
-	my $tmp = File::Temp->new( SUFFIX => $suffix );
-	my $tmp_filename = $tmp->filename;
+	my $tmp_filename = Path::Tiny->tempfile( SUFFIX => $suffix );
 	capture_stderr( sub {
-	#$w->output( 'pngcairo', solid=>1, color=>1,font=>'Arial,10',size=>[11,8.5,'in'] );
-	#$gpwin->output( 'pngcairo', solid=>1, color=>1,font=>'Arial,10',size=>[11,8.5,'in'] );
-	$gpwin->option( hardcopy => $tmp_filename );
-	$gpwin->replot();
-	$gpwin->close;
-
+		$gpwin->option( hardcopy => "$tmp_filename" );
+		$gpwin->replot();
+		$gpwin->close;
 	});
 
 	capture_stderr( sub  {

--- a/lib/Devel/IPerl/Plugin/PDLGraphicsGnuplot.pm
+++ b/lib/Devel/IPerl/Plugin/PDLGraphicsGnuplot.pm
@@ -35,6 +35,10 @@ around new => sub {
 	my $gpwin = $orig->(@_);
 
 	if( $Devel::IPerl::Plugin::PDLGraphicsGnuplot::IPerl_compat ) {
+		# We turn on dumping so that the plot does not go to an actual
+		# terminal (a "dry-run"). This is so that we can actually have
+		# the output go to a terminal later when
+		# C<iperl_data_representations> is called.
 		capture_stderr(sub {
 			# capture to avoid printing out the dumping warning
 			$gpwin->option( dump => 1 );

--- a/t/plugin_pggnuplot.t
+++ b/t/plugin_pggnuplot.t
@@ -1,4 +1,4 @@
-use Test::Most tests => 1;
+use Test::Most tests => 2;
 
 use strict;
 use warnings;
@@ -22,12 +22,9 @@ sub run_plot {
 	my $data = $w->iperl_data_representations;
 }
 
-lives_ok { run_plot() } 'plotting does not die';
+my $data;
+lives_ok { $data = run_plot() } 'plotting does not die';
 
-#use DDP; p $data->{'text/html'};
-#use Path::Class;
-#file('/tmp/b.png')->spew( iomode => '>:raw', $data->{'image/png'} );
-
-#use DDP; p $w->iperl_data_representations;
+like $data->{'image/svg+xml'}, qr/<svg[^>]+>/s, 'has <svg> tag';
 
 done_testing;


### PR DESCRIPTION
This returns a temporary filename that is unopened. This allows for
Gnuplot to write to the same file since the Perl process will not be
holding on to the filehandle. This is particularly important on Windows
since it only allows a single process to access a file at a time.

![selection_044](https://user-images.githubusercontent.com/94489/34176133-78f140f4-e4c4-11e7-8021-09e057489a4d.png)
